### PR TITLE
Fixed crash when on empty line, & compile issues

### DIFF
--- a/CASCExplorer/CASCConfig.cs
+++ b/CASCExplorer/CASCConfig.cs
@@ -17,6 +17,9 @@ namespace CASCExplorer
 
                 while ((line = sr.ReadLine()) != null)
                 {
+                    if (line == string.Empty) // skip empty lines
+                        continue;
+
                     if (line.StartsWith("#")) // skip comments
                         continue;
 

--- a/CASCExplorer/CASCHandler.cs
+++ b/CASCExplorer/CASCHandler.cs
@@ -396,7 +396,8 @@ namespace CASCExplorer
             {
                 if (key.EqualsTo(CASCConfig.EncodingKey))
                 {
-                    using (Stream s = CDNHandler.OpenDataFileDirect(key, out int len))
+                    int len;
+                    using (Stream s = CDNHandler.OpenDataFileDirect(key, out len))
                     using (BLTEHandler blte = new BLTEHandler(s, len))
                         return blte.OpenFile();
                 }
@@ -443,7 +444,8 @@ namespace CASCExplorer
             {
                 if (key.EqualsTo(CASCConfig.EncodingKey))
                 {
-                    using (Stream s = CDNHandler.OpenDataFileDirect(key, out int len))
+                    int len;
+                    using (Stream s = CDNHandler.OpenDataFileDirect(key, out len))
                     using (BLTEHandler blte = new BLTEHandler(s, len))
                         blte.ExtractToFile(path, name);
                 }


### PR DESCRIPTION
Fixed an exception that was thrown when CASCConfig encountered an empty line.
Fixed compile issues related to out parameters in CASCHandler.